### PR TITLE
Advanced docs: make clear which specifications the docs refer to

### DIFF
--- a/doc/advanced.md
+++ b/doc/advanced.md
@@ -1,7 +1,7 @@
 
 # Advanced vtzero topics
 
-## Differences between the specification and the vtzero implementation
+## Differences between the protocol buffer specification and the vtzero implementation
 
 The [protobuf specification
 says](https://developers.google.com/protocol-buffers/docs/encoding#optional)
@@ -11,7 +11,10 @@ as if the items are concatenated. Encoders should never encode fields in this
 way, though, so it is very unlikely that this would ever happen. For
 performance reasons vtzero doesn't handle this case.
 
-The vtzero spec clearly says that you can not have two layers with the same
+## Differences between the vector tile specification and the vtzero implementation
+
+The [vector tile specification](https://github.com/mapbox/vector-tile-spec/blob/master/2.1/README.md#41-layers)
+clearly says that you can not have two layers with the same
 name in a vector tile. For performance reasons this is neither checked on
 reading nor on writing.
 


### PR DESCRIPTION
This corrects the docs to refer to the `vector tile specification` rather than the `vtzero spec`.