### PR TITLE
Actually add boost headers to includes

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,7 @@
 if(Boost_FOUND)
     message(STATUS "Boost library found: enable testing with boost::variant")
     add_definitions(-DVTZERO_TEST_WITH_VARIANT)
+    include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 else()
     message(STATUS "Boost library not found: disable testing with boost::variant")
 endif()


### PR DESCRIPTION
On my system, boost was being found but the compile would fail since the headers for boost were not being added.