### PR TITLE
Make Command API Explicit

### DIFF
--- a/include/vtzero/builder.hpp
+++ b/include/vtzero/builder.hpp
@@ -1013,7 +1013,7 @@ namespace vtzero {
             } else if (m_num_points.value() == 0) {
                 vtzero_assert(m_first_point == p); // XXX
                 // spec 4.3.3.3 "A ClosePath command MUST have a command count of 1"
-                m_pbf_geometry.add_element(detail::command_close_path(1));
+                m_pbf_geometry.add_element(detail::command_close_path());
             } else {
                 vtzero_assert(m_cursor != p); // XXX
                 m_pbf_geometry.add_element(protozero::encode_zigzag32(p.x - m_cursor.x));
@@ -1074,7 +1074,7 @@ namespace vtzero {
                           "close_ring() has to be called before properties are added");
             vtzero_assert(m_num_points.value() == 1 &&
                           "wrong number of points in ring");
-            m_pbf_geometry.add_element(detail::command_close_path(1));
+            m_pbf_geometry.add_element(detail::command_close_path());
             m_num_points.decrement();
         }
 

--- a/include/vtzero/geometry.hpp
+++ b/include/vtzero/geometry.hpp
@@ -79,14 +79,14 @@ namespace vtzero {
         return !(a==b);
     }
 
-    /// The command id type as specified in the vector tile spec
-    enum CommandId : uint32_t {
-        MOVE_TO = 1,
-        LINE_TO = 2,
-        CLOSE_PATH = 7
-    };
-
     namespace detail {
+
+        /// The command id type as specified in the vector tile spec
+        enum CommandId : uint32_t {
+            MOVE_TO = 1,
+            LINE_TO = 2,
+            CLOSE_PATH = 7
+        };
 
         inline constexpr uint32_t command_integer(const uint32_t id, const uint32_t count) noexcept {
             return (id & 0x7) | (count << 3);

--- a/include/vtzero/geometry.hpp
+++ b/include/vtzero/geometry.hpp
@@ -88,7 +88,6 @@ namespace vtzero {
 
     namespace detail {
 
-        
         inline constexpr uint32_t command_integer(const uint32_t id, const uint32_t count) noexcept {
             return (id & 0x7) | (count << 3);
         }
@@ -202,7 +201,7 @@ namespace vtzero {
                 if (m_it == m_end) {
                     return false;
                 }
-                
+
                 m_command_id = get_command_id(*m_it);
                 if (m_command_id != expected_command_id) {
                     throw geometry_exception{std::string{"expected command "} +

--- a/test/t/test_geometry.cpp
+++ b/test/t/test_geometry.cpp
@@ -17,7 +17,7 @@ TEST_CASE("geometry_decoder") {
 
     REQUIRE(decoder.count() == 0);
     REQUIRE(decoder.done());
-    REQUIRE_FALSE(decoder.next_command(vtzero::detail::command_move_to()));
+    REQUIRE_FALSE(decoder.next_command(vtzero::CommandId::MOVE_TO));
     REQUIRE_THROWS_AS(decoder.next_point(), const assert_error&);
 }
 
@@ -31,21 +31,21 @@ TEST_CASE("geometry_decoder with point") {
     REQUIRE_THROWS_AS(decoder.next_point(), const assert_error&);
 
     SECTION("trying to get LineTo command") {
-        REQUIRE_THROWS_AS(decoder.next_command(vtzero::detail::command_line_to()), const vtzero::geometry_exception&);
+        REQUIRE_THROWS_AS(decoder.next_command(vtzero::CommandId::LINE_TO), const vtzero::geometry_exception&);
     }
 
     SECTION("trying to get ClosePath command") {
-        REQUIRE_THROWS_WITH(decoder.next_command(vtzero::detail::command_close_path()), "expected command 7 but got 1");
+        REQUIRE_THROWS_WITH(decoder.next_command(vtzero::CommandId::CLOSE_PATH), "expected command 7 but got 1");
     }
 
     SECTION("trying to get MoveTo command") {
-        REQUIRE(decoder.next_command(vtzero::detail::command_move_to()));
-        REQUIRE_THROWS_AS(decoder.next_command(vtzero::detail::command_move_to()), const assert_error&);
+        REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
+        REQUIRE_THROWS_AS(decoder.next_command(vtzero::CommandId::MOVE_TO), const assert_error&);
         REQUIRE(decoder.count() == 1);
         REQUIRE(decoder.next_point() == vtzero::point(25, 17));
 
         REQUIRE(decoder.done());
-        REQUIRE_FALSE(decoder.next_command(vtzero::detail::command_move_to()));
+        REQUIRE_FALSE(decoder.next_command(vtzero::CommandId::MOVE_TO));
     }
 }
 
@@ -65,7 +65,7 @@ TEST_CASE("geometry_decoder with incomplete point") {
     REQUIRE(decoder.count() == 0);
     REQUIRE_FALSE(decoder.done());
 
-    REQUIRE(decoder.next_command(vtzero::detail::command_move_to()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
     REQUIRE(decoder.count() == 1);
     REQUIRE_THROWS_AS(decoder.next_point(), const vtzero::geometry_exception&);
 }
@@ -77,7 +77,7 @@ TEST_CASE("geometry_decoder with multipoint") {
     REQUIRE(decoder.count() == 0);
     REQUIRE_FALSE(decoder.done());
 
-    REQUIRE(decoder.next_command(vtzero::detail::command_move_to()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
     REQUIRE(decoder.count() == 2);
     REQUIRE(decoder.next_point() == vtzero::point(5, 7));
     REQUIRE(decoder.count() == 1);
@@ -85,7 +85,7 @@ TEST_CASE("geometry_decoder with multipoint") {
     REQUIRE(decoder.count() == 0);
 
     REQUIRE(decoder.done());
-    REQUIRE_FALSE(decoder.next_command(vtzero::detail::command_move_to()));
+    REQUIRE_FALSE(decoder.next_command(vtzero::CommandId::MOVE_TO));
 }
 
 TEST_CASE("geometry_decoder with linestring") {
@@ -95,10 +95,10 @@ TEST_CASE("geometry_decoder with linestring") {
     REQUIRE(decoder.count() == 0);
     REQUIRE_FALSE(decoder.done());
 
-    REQUIRE(decoder.next_command(vtzero::detail::command_move_to()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(2, 2));
-    REQUIRE(decoder.next_command(vtzero::detail::command_line_to()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::LINE_TO));
     REQUIRE(decoder.count() == 2);
     REQUIRE(decoder.next_point() == vtzero::point(2, 10));
     REQUIRE(decoder.count() == 1);
@@ -106,7 +106,7 @@ TEST_CASE("geometry_decoder with linestring") {
     REQUIRE(decoder.count() == 0);
 
     REQUIRE(decoder.done());
-    REQUIRE_FALSE(decoder.next_command(vtzero::detail::command_move_to()));
+    REQUIRE_FALSE(decoder.next_command(vtzero::CommandId::MOVE_TO));
 }
 
 TEST_CASE("geometry_decoder with linestring with equal points") {
@@ -116,10 +116,10 @@ TEST_CASE("geometry_decoder with linestring with equal points") {
     REQUIRE(decoder.count() == 0);
     REQUIRE_FALSE(decoder.done());
 
-    REQUIRE(decoder.next_command(vtzero::detail::command_move_to()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(2, 2));
-    REQUIRE(decoder.next_command(vtzero::detail::command_line_to()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::LINE_TO));
     REQUIRE(decoder.count() == 2);
     REQUIRE(decoder.next_point() == vtzero::point(2, 10));
     REQUIRE(decoder.count() == 1);
@@ -137,27 +137,27 @@ TEST_CASE("geometry_decoder with multilinestring") {
     REQUIRE(decoder.count() == 0);
     REQUIRE_FALSE(decoder.done());
 
-    REQUIRE(decoder.next_command(vtzero::detail::command_move_to()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(2, 2));
-    REQUIRE(decoder.next_command(vtzero::detail::command_line_to()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::LINE_TO));
     REQUIRE(decoder.count() == 2);
     REQUIRE(decoder.next_point() == vtzero::point(2, 10));
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(10, 10));
     REQUIRE(decoder.count() == 0);
 
-    REQUIRE(decoder.next_command(vtzero::detail::command_move_to()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(1, 1));
     REQUIRE(decoder.count() == 0);
-    REQUIRE(decoder.next_command(vtzero::detail::command_line_to()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::LINE_TO));
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(3, 5));
     REQUIRE(decoder.count() == 0);
 
     REQUIRE(decoder.done());
-    REQUIRE_FALSE(decoder.next_command(vtzero::detail::command_move_to()));
+    REQUIRE_FALSE(decoder.next_command(vtzero::CommandId::MOVE_TO));
 }
 
 TEST_CASE("geometry_decoder with polygon") {
@@ -167,35 +167,52 @@ TEST_CASE("geometry_decoder with polygon") {
     REQUIRE(decoder.count() == 0);
     REQUIRE_FALSE(decoder.done());
 
-    REQUIRE(decoder.next_command(vtzero::detail::command_move_to()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(3, 6));
-    REQUIRE(decoder.next_command(vtzero::detail::command_line_to()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::LINE_TO));
     REQUIRE(decoder.count() == 2);
     REQUIRE(decoder.next_point() == vtzero::point(8, 12));
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(20, 34));
     REQUIRE(decoder.count() == 0);
-    REQUIRE(decoder.next_command(vtzero::detail::command_close_path()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::CLOSE_PATH));
     REQUIRE(decoder.count() == 0);
 
     REQUIRE(decoder.done());
-    REQUIRE_FALSE(decoder.next_command(vtzero::detail::command_move_to()));
+    REQUIRE_FALSE(decoder.next_command(vtzero::CommandId::MOVE_TO));
 }
 
-TEST_CASE("geometry_decoder with polygon with wrong ClosePath count") {
+TEST_CASE("geometry_decoder with polygon with wrong ClosePath count 2") {
     const container g = {9, 6, 12, 18, 10, 12, 24, 44, 23};
 
     vtzero::detail::geometry_decoder<iterator> decoder{g.cbegin(), g.cend(), g.size() / 2};
     REQUIRE(decoder.count() == 0);
     REQUIRE_FALSE(decoder.done());
 
-    REQUIRE(decoder.next_command(vtzero::detail::command_move_to()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
     REQUIRE(decoder.next_point() == vtzero::point(3, 6));
-    REQUIRE(decoder.next_command(vtzero::detail::command_line_to()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::LINE_TO));
     REQUIRE(decoder.next_point() == vtzero::point(8, 12));
     REQUIRE(decoder.next_point() == vtzero::point(20, 34));
-    REQUIRE_THROWS_AS(decoder.next_command(vtzero::detail::command_close_path()), const vtzero::geometry_exception&);
+    REQUIRE_THROWS_AS(decoder.next_command(vtzero::CommandId::CLOSE_PATH), const vtzero::geometry_exception&);
+    REQUIRE_THROWS_WITH(decoder.next_command(vtzero::CommandId::CLOSE_PATH), "ClosePath command count is not 1");
+}
+
+TEST_CASE("geometry_decoder with polygon with wrong ClosePath count 0") {
+    const container g = {9, 6, 12, 18, 10, 12, 24, 44, 7};
+
+    vtzero::detail::geometry_decoder<iterator> decoder{g.cbegin(), g.cend(), g.size() / 2};
+    REQUIRE(decoder.count() == 0);
+    REQUIRE_FALSE(decoder.done());
+
+    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
+    REQUIRE(decoder.next_point() == vtzero::point(3, 6));
+    REQUIRE(decoder.next_command(vtzero::CommandId::LINE_TO));
+    REQUIRE(decoder.next_point() == vtzero::point(8, 12));
+    REQUIRE(decoder.next_point() == vtzero::point(20, 34));
+    REQUIRE_THROWS_AS(decoder.next_command(vtzero::CommandId::CLOSE_PATH), const vtzero::geometry_exception&);
+    REQUIRE_THROWS_WITH(decoder.next_command(vtzero::CommandId::CLOSE_PATH), "ClosePath command count is not 1");
 }
 
 TEST_CASE("geometry_decoder with multipolygon") {
@@ -206,10 +223,10 @@ TEST_CASE("geometry_decoder with multipolygon") {
     REQUIRE(decoder.count() == 0);
     REQUIRE_FALSE(decoder.done());
 
-    REQUIRE(decoder.next_command(vtzero::detail::command_move_to()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(0, 0));
-    REQUIRE(decoder.next_command(vtzero::detail::command_line_to()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::LINE_TO));
     REQUIRE(decoder.count() == 3);
     REQUIRE(decoder.next_point() == vtzero::point(10, 0));
     REQUIRE(decoder.count() == 2);
@@ -217,13 +234,13 @@ TEST_CASE("geometry_decoder with multipolygon") {
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(0, 10));
     REQUIRE(decoder.count() == 0);
-    REQUIRE(decoder.next_command(vtzero::detail::command_close_path()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::CLOSE_PATH));
     REQUIRE(decoder.count() == 0);
 
-    REQUIRE(decoder.next_command(vtzero::detail::command_move_to()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(11, 11));
-    REQUIRE(decoder.next_command(vtzero::detail::command_line_to()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::LINE_TO));
     REQUIRE(decoder.count() == 3);
     REQUIRE(decoder.next_point() == vtzero::point(20, 11));
     REQUIRE(decoder.count() == 2);
@@ -231,13 +248,13 @@ TEST_CASE("geometry_decoder with multipolygon") {
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(11, 20));
     REQUIRE(decoder.count() == 0);
-    REQUIRE(decoder.next_command(vtzero::detail::command_close_path()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::CLOSE_PATH));
     REQUIRE(decoder.count() == 0);
 
-    REQUIRE(decoder.next_command(vtzero::detail::command_move_to()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(13, 13));
-    REQUIRE(decoder.next_command(vtzero::detail::command_line_to()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::LINE_TO));
     REQUIRE(decoder.count() == 3);
     REQUIRE(decoder.next_point() == vtzero::point(13, 17));
     REQUIRE(decoder.count() == 2);
@@ -245,11 +262,11 @@ TEST_CASE("geometry_decoder with multipolygon") {
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(17, 13));
     REQUIRE(decoder.count() == 0);
-    REQUIRE(decoder.next_command(vtzero::detail::command_close_path()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::CLOSE_PATH));
     REQUIRE(decoder.count() == 0);
 
     REQUIRE(decoder.done());
-    REQUIRE_FALSE(decoder.next_command(vtzero::detail::command_move_to()));
+    REQUIRE_FALSE(decoder.next_command(vtzero::CommandId::MOVE_TO));
 }
 
 TEST_CASE("geometry_decoder decoding linestring with int32 overflow in x coordinate") {
@@ -265,10 +282,10 @@ TEST_CASE("geometry_decoder decoding linestring with int32 overflow in x coordin
     REQUIRE(decoder.count() == 0);
     REQUIRE_FALSE(decoder.done());
 
-    REQUIRE(decoder.next_command(vtzero::detail::command_move_to()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(std::numeric_limits<int32_t>::max(), 0));
-    REQUIRE(decoder.next_command(vtzero::detail::command_line_to()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::LINE_TO));
     REQUIRE(decoder.count() == 1);
     decoder.next_point();
 }
@@ -286,10 +303,10 @@ TEST_CASE("geometry_decoder decoding linestring with int32 overflow in y coordin
     REQUIRE(decoder.count() == 0);
     REQUIRE_FALSE(decoder.done());
 
-    REQUIRE(decoder.next_command(vtzero::detail::command_move_to()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(0, std::numeric_limits<int32_t>::min()));
-    REQUIRE(decoder.next_command(vtzero::detail::command_line_to()));
+    REQUIRE(decoder.next_command(vtzero::CommandId::LINE_TO));
     REQUIRE(decoder.count() == 1);
     decoder.next_point();
 }
@@ -302,7 +319,7 @@ TEST_CASE("geometry_decoder with multipoint with a huge count") {
     REQUIRE(decoder.count() == 0);
     REQUIRE_FALSE(decoder.done());
 
-    REQUIRE_THROWS_AS(decoder.next_command(vtzero::detail::command_move_to()), const vtzero::geometry_exception&);
+    REQUIRE_THROWS_AS(decoder.next_command(vtzero::CommandId::MOVE_TO), const vtzero::geometry_exception&);
 }
 
 TEST_CASE("geometry_decoder with multipoint with not enough points") {
@@ -312,6 +329,6 @@ TEST_CASE("geometry_decoder with multipoint with not enough points") {
     REQUIRE(decoder.count() == 0);
     REQUIRE_FALSE(decoder.done());
 
-    REQUIRE_THROWS_AS(decoder.next_command(vtzero::detail::command_move_to()), const vtzero::geometry_exception&);
+    REQUIRE_THROWS_AS(decoder.next_command(vtzero::CommandId::MOVE_TO), const vtzero::geometry_exception&);
 }
 

--- a/test/t/test_geometry.cpp
+++ b/test/t/test_geometry.cpp
@@ -17,7 +17,7 @@ TEST_CASE("geometry_decoder") {
 
     REQUIRE(decoder.count() == 0);
     REQUIRE(decoder.done());
-    REQUIRE_FALSE(decoder.next_command(vtzero::CommandId::MOVE_TO));
+    REQUIRE_FALSE(decoder.next_command(vtzero::detail::CommandId::MOVE_TO));
     REQUIRE_THROWS_AS(decoder.next_point(), const assert_error&);
 }
 
@@ -31,21 +31,21 @@ TEST_CASE("geometry_decoder with point") {
     REQUIRE_THROWS_AS(decoder.next_point(), const assert_error&);
 
     SECTION("trying to get LineTo command") {
-        REQUIRE_THROWS_AS(decoder.next_command(vtzero::CommandId::LINE_TO), const vtzero::geometry_exception&);
+        REQUIRE_THROWS_AS(decoder.next_command(vtzero::detail::CommandId::LINE_TO), const vtzero::geometry_exception&);
     }
 
     SECTION("trying to get ClosePath command") {
-        REQUIRE_THROWS_WITH(decoder.next_command(vtzero::CommandId::CLOSE_PATH), "expected command 7 but got 1");
+        REQUIRE_THROWS_WITH(decoder.next_command(vtzero::detail::CommandId::CLOSE_PATH), "expected command 7 but got 1");
     }
 
     SECTION("trying to get MoveTo command") {
-        REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
-        REQUIRE_THROWS_AS(decoder.next_command(vtzero::CommandId::MOVE_TO), const assert_error&);
+        REQUIRE(decoder.next_command(vtzero::detail::CommandId::MOVE_TO));
+        REQUIRE_THROWS_AS(decoder.next_command(vtzero::detail::CommandId::MOVE_TO), const assert_error&);
         REQUIRE(decoder.count() == 1);
         REQUIRE(decoder.next_point() == vtzero::point(25, 17));
 
         REQUIRE(decoder.done());
-        REQUIRE_FALSE(decoder.next_command(vtzero::CommandId::MOVE_TO));
+        REQUIRE_FALSE(decoder.next_command(vtzero::detail::CommandId::MOVE_TO));
     }
 }
 
@@ -65,7 +65,7 @@ TEST_CASE("geometry_decoder with incomplete point") {
     REQUIRE(decoder.count() == 0);
     REQUIRE_FALSE(decoder.done());
 
-    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::MOVE_TO));
     REQUIRE(decoder.count() == 1);
     REQUIRE_THROWS_AS(decoder.next_point(), const vtzero::geometry_exception&);
 }
@@ -77,7 +77,7 @@ TEST_CASE("geometry_decoder with multipoint") {
     REQUIRE(decoder.count() == 0);
     REQUIRE_FALSE(decoder.done());
 
-    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::MOVE_TO));
     REQUIRE(decoder.count() == 2);
     REQUIRE(decoder.next_point() == vtzero::point(5, 7));
     REQUIRE(decoder.count() == 1);
@@ -85,7 +85,7 @@ TEST_CASE("geometry_decoder with multipoint") {
     REQUIRE(decoder.count() == 0);
 
     REQUIRE(decoder.done());
-    REQUIRE_FALSE(decoder.next_command(vtzero::CommandId::MOVE_TO));
+    REQUIRE_FALSE(decoder.next_command(vtzero::detail::CommandId::MOVE_TO));
 }
 
 TEST_CASE("geometry_decoder with linestring") {
@@ -95,10 +95,10 @@ TEST_CASE("geometry_decoder with linestring") {
     REQUIRE(decoder.count() == 0);
     REQUIRE_FALSE(decoder.done());
 
-    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::MOVE_TO));
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(2, 2));
-    REQUIRE(decoder.next_command(vtzero::CommandId::LINE_TO));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::LINE_TO));
     REQUIRE(decoder.count() == 2);
     REQUIRE(decoder.next_point() == vtzero::point(2, 10));
     REQUIRE(decoder.count() == 1);
@@ -106,7 +106,7 @@ TEST_CASE("geometry_decoder with linestring") {
     REQUIRE(decoder.count() == 0);
 
     REQUIRE(decoder.done());
-    REQUIRE_FALSE(decoder.next_command(vtzero::CommandId::MOVE_TO));
+    REQUIRE_FALSE(decoder.next_command(vtzero::detail::CommandId::MOVE_TO));
 }
 
 TEST_CASE("geometry_decoder with linestring with equal points") {
@@ -116,10 +116,10 @@ TEST_CASE("geometry_decoder with linestring with equal points") {
     REQUIRE(decoder.count() == 0);
     REQUIRE_FALSE(decoder.done());
 
-    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::MOVE_TO));
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(2, 2));
-    REQUIRE(decoder.next_command(vtzero::CommandId::LINE_TO));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::LINE_TO));
     REQUIRE(decoder.count() == 2);
     REQUIRE(decoder.next_point() == vtzero::point(2, 10));
     REQUIRE(decoder.count() == 1);
@@ -137,27 +137,27 @@ TEST_CASE("geometry_decoder with multilinestring") {
     REQUIRE(decoder.count() == 0);
     REQUIRE_FALSE(decoder.done());
 
-    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::MOVE_TO));
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(2, 2));
-    REQUIRE(decoder.next_command(vtzero::CommandId::LINE_TO));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::LINE_TO));
     REQUIRE(decoder.count() == 2);
     REQUIRE(decoder.next_point() == vtzero::point(2, 10));
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(10, 10));
     REQUIRE(decoder.count() == 0);
 
-    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::MOVE_TO));
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(1, 1));
     REQUIRE(decoder.count() == 0);
-    REQUIRE(decoder.next_command(vtzero::CommandId::LINE_TO));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::LINE_TO));
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(3, 5));
     REQUIRE(decoder.count() == 0);
 
     REQUIRE(decoder.done());
-    REQUIRE_FALSE(decoder.next_command(vtzero::CommandId::MOVE_TO));
+    REQUIRE_FALSE(decoder.next_command(vtzero::detail::CommandId::MOVE_TO));
 }
 
 TEST_CASE("geometry_decoder with polygon") {
@@ -167,20 +167,20 @@ TEST_CASE("geometry_decoder with polygon") {
     REQUIRE(decoder.count() == 0);
     REQUIRE_FALSE(decoder.done());
 
-    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::MOVE_TO));
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(3, 6));
-    REQUIRE(decoder.next_command(vtzero::CommandId::LINE_TO));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::LINE_TO));
     REQUIRE(decoder.count() == 2);
     REQUIRE(decoder.next_point() == vtzero::point(8, 12));
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(20, 34));
     REQUIRE(decoder.count() == 0);
-    REQUIRE(decoder.next_command(vtzero::CommandId::CLOSE_PATH));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::CLOSE_PATH));
     REQUIRE(decoder.count() == 0);
 
     REQUIRE(decoder.done());
-    REQUIRE_FALSE(decoder.next_command(vtzero::CommandId::MOVE_TO));
+    REQUIRE_FALSE(decoder.next_command(vtzero::detail::CommandId::MOVE_TO));
 }
 
 TEST_CASE("geometry_decoder with polygon with wrong ClosePath count 2") {
@@ -190,13 +190,13 @@ TEST_CASE("geometry_decoder with polygon with wrong ClosePath count 2") {
     REQUIRE(decoder.count() == 0);
     REQUIRE_FALSE(decoder.done());
 
-    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::MOVE_TO));
     REQUIRE(decoder.next_point() == vtzero::point(3, 6));
-    REQUIRE(decoder.next_command(vtzero::CommandId::LINE_TO));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::LINE_TO));
     REQUIRE(decoder.next_point() == vtzero::point(8, 12));
     REQUIRE(decoder.next_point() == vtzero::point(20, 34));
-    REQUIRE_THROWS_AS(decoder.next_command(vtzero::CommandId::CLOSE_PATH), const vtzero::geometry_exception&);
-    REQUIRE_THROWS_WITH(decoder.next_command(vtzero::CommandId::CLOSE_PATH), "ClosePath command count is not 1");
+    REQUIRE_THROWS_AS(decoder.next_command(vtzero::detail::CommandId::CLOSE_PATH), const vtzero::geometry_exception&);
+    REQUIRE_THROWS_WITH(decoder.next_command(vtzero::detail::CommandId::CLOSE_PATH), "ClosePath command count is not 1");
 }
 
 TEST_CASE("geometry_decoder with polygon with wrong ClosePath count 0") {
@@ -206,13 +206,13 @@ TEST_CASE("geometry_decoder with polygon with wrong ClosePath count 0") {
     REQUIRE(decoder.count() == 0);
     REQUIRE_FALSE(decoder.done());
 
-    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::MOVE_TO));
     REQUIRE(decoder.next_point() == vtzero::point(3, 6));
-    REQUIRE(decoder.next_command(vtzero::CommandId::LINE_TO));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::LINE_TO));
     REQUIRE(decoder.next_point() == vtzero::point(8, 12));
     REQUIRE(decoder.next_point() == vtzero::point(20, 34));
-    REQUIRE_THROWS_AS(decoder.next_command(vtzero::CommandId::CLOSE_PATH), const vtzero::geometry_exception&);
-    REQUIRE_THROWS_WITH(decoder.next_command(vtzero::CommandId::CLOSE_PATH), "ClosePath command count is not 1");
+    REQUIRE_THROWS_AS(decoder.next_command(vtzero::detail::CommandId::CLOSE_PATH), const vtzero::geometry_exception&);
+    REQUIRE_THROWS_WITH(decoder.next_command(vtzero::detail::CommandId::CLOSE_PATH), "ClosePath command count is not 1");
 }
 
 TEST_CASE("geometry_decoder with multipolygon") {
@@ -223,10 +223,10 @@ TEST_CASE("geometry_decoder with multipolygon") {
     REQUIRE(decoder.count() == 0);
     REQUIRE_FALSE(decoder.done());
 
-    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::MOVE_TO));
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(0, 0));
-    REQUIRE(decoder.next_command(vtzero::CommandId::LINE_TO));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::LINE_TO));
     REQUIRE(decoder.count() == 3);
     REQUIRE(decoder.next_point() == vtzero::point(10, 0));
     REQUIRE(decoder.count() == 2);
@@ -234,13 +234,13 @@ TEST_CASE("geometry_decoder with multipolygon") {
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(0, 10));
     REQUIRE(decoder.count() == 0);
-    REQUIRE(decoder.next_command(vtzero::CommandId::CLOSE_PATH));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::CLOSE_PATH));
     REQUIRE(decoder.count() == 0);
 
-    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::MOVE_TO));
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(11, 11));
-    REQUIRE(decoder.next_command(vtzero::CommandId::LINE_TO));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::LINE_TO));
     REQUIRE(decoder.count() == 3);
     REQUIRE(decoder.next_point() == vtzero::point(20, 11));
     REQUIRE(decoder.count() == 2);
@@ -248,13 +248,13 @@ TEST_CASE("geometry_decoder with multipolygon") {
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(11, 20));
     REQUIRE(decoder.count() == 0);
-    REQUIRE(decoder.next_command(vtzero::CommandId::CLOSE_PATH));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::CLOSE_PATH));
     REQUIRE(decoder.count() == 0);
 
-    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::MOVE_TO));
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(13, 13));
-    REQUIRE(decoder.next_command(vtzero::CommandId::LINE_TO));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::LINE_TO));
     REQUIRE(decoder.count() == 3);
     REQUIRE(decoder.next_point() == vtzero::point(13, 17));
     REQUIRE(decoder.count() == 2);
@@ -262,11 +262,11 @@ TEST_CASE("geometry_decoder with multipolygon") {
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(17, 13));
     REQUIRE(decoder.count() == 0);
-    REQUIRE(decoder.next_command(vtzero::CommandId::CLOSE_PATH));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::CLOSE_PATH));
     REQUIRE(decoder.count() == 0);
 
     REQUIRE(decoder.done());
-    REQUIRE_FALSE(decoder.next_command(vtzero::CommandId::MOVE_TO));
+    REQUIRE_FALSE(decoder.next_command(vtzero::detail::CommandId::MOVE_TO));
 }
 
 TEST_CASE("geometry_decoder decoding linestring with int32 overflow in x coordinate") {
@@ -282,10 +282,10 @@ TEST_CASE("geometry_decoder decoding linestring with int32 overflow in x coordin
     REQUIRE(decoder.count() == 0);
     REQUIRE_FALSE(decoder.done());
 
-    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::MOVE_TO));
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(std::numeric_limits<int32_t>::max(), 0));
-    REQUIRE(decoder.next_command(vtzero::CommandId::LINE_TO));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::LINE_TO));
     REQUIRE(decoder.count() == 1);
     decoder.next_point();
 }
@@ -303,10 +303,10 @@ TEST_CASE("geometry_decoder decoding linestring with int32 overflow in y coordin
     REQUIRE(decoder.count() == 0);
     REQUIRE_FALSE(decoder.done());
 
-    REQUIRE(decoder.next_command(vtzero::CommandId::MOVE_TO));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::MOVE_TO));
     REQUIRE(decoder.count() == 1);
     REQUIRE(decoder.next_point() == vtzero::point(0, std::numeric_limits<int32_t>::min()));
-    REQUIRE(decoder.next_command(vtzero::CommandId::LINE_TO));
+    REQUIRE(decoder.next_command(vtzero::detail::CommandId::LINE_TO));
     REQUIRE(decoder.count() == 1);
     decoder.next_point();
 }
@@ -319,7 +319,7 @@ TEST_CASE("geometry_decoder with multipoint with a huge count") {
     REQUIRE(decoder.count() == 0);
     REQUIRE_FALSE(decoder.done());
 
-    REQUIRE_THROWS_AS(decoder.next_command(vtzero::CommandId::MOVE_TO), const vtzero::geometry_exception&);
+    REQUIRE_THROWS_AS(decoder.next_command(vtzero::detail::CommandId::MOVE_TO), const vtzero::geometry_exception&);
 }
 
 TEST_CASE("geometry_decoder with multipoint with not enough points") {
@@ -329,6 +329,6 @@ TEST_CASE("geometry_decoder with multipoint with not enough points") {
     REQUIRE(decoder.count() == 0);
     REQUIRE_FALSE(decoder.done());
 
-    REQUIRE_THROWS_AS(decoder.next_command(vtzero::CommandId::MOVE_TO), const vtzero::geometry_exception&);
+    REQUIRE_THROWS_AS(decoder.next_command(vtzero::detail::CommandId::MOVE_TO), const vtzero::geometry_exception&);
 }
 

--- a/test/t/test_geometry_polygon.cpp
+++ b/test/t/test_geometry_polygon.cpp
@@ -156,7 +156,7 @@ TEST_CASE("Calling decode_polygon_geometry() with 2nd command not a LineTo") {
 TEST_CASE("Calling decode_polygon_geometry() with LineTo and 0 count") {
     const container g = {vtzero::detail::command_move_to(1), 3, 4,
                          vtzero::detail::command_line_to(0),
-                         vtzero::detail::command_close_path(1)};
+                         vtzero::detail::command_close_path()};
     vtzero::detail::geometry_decoder<container::const_iterator> decoder{g.begin(), g.end(), g.size() / 2};
 
     dummy_geom_handler handler;
@@ -167,7 +167,7 @@ TEST_CASE("Calling decode_polygon_geometry() with LineTo and 0 count") {
 TEST_CASE("Calling decode_polygon_geometry() with LineTo and 1 count") {
     const container g = {vtzero::detail::command_move_to(1), 3, 4,
                          vtzero::detail::command_line_to(1), 5, 6,
-                         vtzero::detail::command_close_path(1)};
+                         vtzero::detail::command_close_path()};
 
     vtzero::detail::geometry_decoder<container::const_iterator> decoder{g.begin(), g.end(), g.size() / 2};
     dummy_geom_handler handler;
@@ -194,7 +194,7 @@ TEST_CASE("Calling decode_polygon_geometry() with 3nd command not a ClosePath") 
 TEST_CASE("Calling decode_polygon_geometry() on polygon with zero area") {
     const container g = {vtzero::detail::command_move_to(1), 0, 0,
                          vtzero::detail::command_line_to(3), 2, 0, 0, 4, 2, 0,
-                         vtzero::detail::command_close_path(1)};
+                         vtzero::detail::command_close_path()};
 
     vtzero::detail::geometry_decoder<container::const_iterator> decoder{g.begin(), g.end(), g.size() / 2};
     dummy_geom_handler handler;


### PR DESCRIPTION
These are a series of changes to make it more difficult in the API to abuse move_to, line_to, close_path commands with invalid counts. Also adds more clear differences between a `uint32_t` response for a `CommandInteger` and `CommandId`