### PR TITLE
add equality operator to vtzero::property

### DIFF
--- a/include/vtzero/property.hpp
+++ b/include/vtzero/property.hpp
@@ -75,8 +75,13 @@ namespace vtzero {
     }; // class property
 
     /// properties are equal if they contain the same key & value data.
-    inline constexpr bool operator==(const property & lhs, property & rhs) noexcept {
+    inline constexpr bool operator==(const property& lhs, const property& rhs) noexcept {
         return lhs.key() == rhs.key() && lhs.value() == rhs.value();
+    }
+
+    /// properties are unequal if they do not contain them same key and value data.
+    inline constexpr bool operator!=(const property& lhs, const property& rhs) noexcept {
+        return lhs.key() != rhs.key() || lhs.value() != rhs.value();
     }
 
 } // namespace vtzero

--- a/include/vtzero/property.hpp
+++ b/include/vtzero/property.hpp
@@ -74,6 +74,11 @@ namespace vtzero {
 
     }; // class property
 
+    /// properties are equal if they contain the same key & value data.
+    inline constexpr bool operator==(const property & lhs, property & rhs) noexcept {
+        return lhs.key() == rhs.key() && lhs.value() == rhs.value();
+    }
+
 } // namespace vtzero
 
 #endif // VTZERO_PROPERTY_HPP

--- a/test/t/test_property_value.cpp
+++ b/test/t/test_property_value.cpp
@@ -374,10 +374,10 @@ TEST_CASE("create encoded property values from different bool types") {
 }
 
 TEST_CASE("property equality comparison operator") {
-    vtzero::data_view k{"key"};
+    std::string k = "key";
+
     vtzero::encoded_property_value epv1{"value"};
     vtzero::encoded_property_value epv2{"another value"};
-
     vtzero::property_value pv1{epv1.data()};
     vtzero::property_value pv2{epv2.data()};
 
@@ -389,11 +389,11 @@ TEST_CASE("property equality comparison operator") {
 }
 
 TEST_CASE("property inequality comparison operator") {
-    vtzero::data_view k1{"key"};
-    vtzero::data_view k2{"another_key"};
+    std::string k1 = "key";
+    std::string k2 = "another_key";
+
     vtzero::encoded_property_value epv1{"value"};
     vtzero::encoded_property_value epv2{"another value"};
-
     vtzero::property_value pv1{epv1.data()};
     vtzero::property_value pv2{epv2.data()};
 

--- a/test/t/test_property_value.cpp
+++ b/test/t/test_property_value.cpp
@@ -373,3 +373,17 @@ TEST_CASE("create encoded property values from different bool types") {
     REQUIRE(b1.hash() == b2.hash());
 }
 
+TEST_CASE("property equality comparison operator") {
+    vtzero::data_view k{"key"};
+    vtzero::encoded_property_value epv1{"value"};
+    vtzero::encoded_property_value epv2{"another value"};
+
+    vtzero::property_value pv1{epv1.data()};
+    vtzero::property_value pv2{epv2.data()};
+
+    vtzero::property p1{k, pv1};
+    vtzero::property p2{k, pv1};
+    vtzero::property p3{k, pv2};
+    REQUIRE(p1 == p2);
+    REQUIRE_FALSE(p1 == p3);
+}

--- a/test/t/test_property_value.cpp
+++ b/test/t/test_property_value.cpp
@@ -387,3 +387,21 @@ TEST_CASE("property equality comparison operator") {
     REQUIRE(p1 == p2);
     REQUIRE_FALSE(p1 == p3);
 }
+
+TEST_CASE("property inequality comparison operator") {
+    vtzero::data_view k1{"key"};
+    vtzero::data_view k2{"another_key"};
+    vtzero::encoded_property_value epv1{"value"};
+    vtzero::encoded_property_value epv2{"another value"};
+
+    vtzero::property_value pv1{epv1.data()};
+    vtzero::property_value pv2{epv2.data()};
+
+    vtzero::property p1{k1, pv1};
+    vtzero::property p2{k1, pv1};
+    vtzero::property p3{k1, pv2};
+    vtzero::property p4{k2, pv2};
+    REQUIRE_FALSE(p1 != p2);
+    REQUIRE(p1 != p3);
+    REQUIRE(p3 != p4);
+}


### PR DESCRIPTION
This adds an `==` equality operator to vtzero::property objects. Helpful in confirming if an entire property (including keys and values) are equal.

Refs: https://github.com/mapbox/vtquery/pull/59

cc @joto @flippmoke 