### PR TITLE
Remove superfluous std::forwards

### DIFF
--- a/include/vtzero/geometry.hpp
+++ b/include/vtzero/geometry.hpp
@@ -262,9 +262,9 @@ namespace vtzero {
                     throw geometry_exception{"MoveTo command count is zero (spec 4.3.4.2)"};
                 }
 
-                std::forward<TGeomHandler>(geom_handler).points_begin(count());
+                geom_handler.points_begin(count());
                 while (count() > 0) {
-                    std::forward<TGeomHandler>(geom_handler).points_point(next_point());
+                    geom_handler.points_point(next_point());
                 }
 
                 // spec 4.3.4.2 "MUST consist of of a single ... command"
@@ -272,7 +272,7 @@ namespace vtzero {
                     throw geometry_exception{"additional data after end of geometry (spec 4.3.4.2)"};
                 }
 
-                std::forward<TGeomHandler>(geom_handler).points_end();
+                geom_handler.points_end();
 
                 return detail::get_result<TGeomHandler>{}(std::forward<TGeomHandler>(geom_handler));
             }
@@ -298,14 +298,14 @@ namespace vtzero {
                         throw geometry_exception{"LineTo command count is zero (spec 4.3.4.3)"};
                     }
 
-                    std::forward<TGeomHandler>(geom_handler).linestring_begin(count() + 1);
+                    geom_handler.linestring_begin(count() + 1);
 
-                    std::forward<TGeomHandler>(geom_handler).linestring_point(first_point);
+                    geom_handler.linestring_point(first_point);
                     while (count() > 0) {
-                        std::forward<TGeomHandler>(geom_handler).linestring_point(next_point());
+                        geom_handler.linestring_point(next_point());
                     }
 
-                    std::forward<TGeomHandler>(geom_handler).linestring_end();
+                    geom_handler.linestring_end();
                 }
 
                 return detail::get_result<TGeomHandler>{}(std::forward<TGeomHandler>(geom_handler));
@@ -329,15 +329,15 @@ namespace vtzero {
                         throw geometry_exception{"expected LineTo command (spec 4.3.4.4)"};
                     }
 
-                    std::forward<TGeomHandler>(geom_handler).ring_begin(count() + 2);
+                    geom_handler.ring_begin(count() + 2);
 
-                    std::forward<TGeomHandler>(geom_handler).ring_point(start_point);
+                    geom_handler.ring_point(start_point);
 
                     while (count() > 0) {
                         const point p = next_point();
                         sum += detail::det(last_point, p);
                         last_point = p;
-                        std::forward<TGeomHandler>(geom_handler).ring_point(p);
+                        geom_handler.ring_point(p);
                     }
 
                     // spec 4.3.4.4 "3. A ClosePath command"
@@ -347,10 +347,10 @@ namespace vtzero {
 
                     sum += detail::det(last_point, start_point);
 
-                    std::forward<TGeomHandler>(geom_handler).ring_point(start_point);
+                    geom_handler.ring_point(start_point);
 
-                    std::forward<TGeomHandler>(geom_handler).ring_end(sum > 0 ? ring_type::outer :
-                                                                      sum < 0 ? ring_type::inner : ring_type::invalid);
+                    geom_handler.ring_end(sum > 0 ? ring_type::outer :
+                                                    sum < 0 ? ring_type::inner : ring_type::invalid);
                 }
 
                 return detail::get_result<TGeomHandler>{}(std::forward<TGeomHandler>(geom_handler));


### PR DESCRIPTION
We should not call std::forward more than once on a variable, because
the variable might be moved from afterwards so we can't use it any
more. In these cases the std::forward is superfluous anyway, so just
remove it.