### PR TITLE
Include <limits> for gcc>=11

### DIFF
--- a/include/vtzero/types.hpp
+++ b/include/vtzero/types.hpp
@@ -14,6 +14,7 @@ documentation.
 
 #include <array>
 #include <cassert>
+#include <limits>
 
 // @cond internal
 // Wrappers for assert() used for testing


### PR DESCRIPTION
gcc>=11 no longer automatically includes <limits>

Fixes #52