### PR TITLE
differentiate degenerate segment exception message for polygon rings vs linestrings

### DIFF
--- a/include/vtzero/builder.hpp
+++ b/include/vtzero/builder.hpp
@@ -1032,7 +1032,7 @@ namespace vtzero {
                 m_pbf_geometry.add_element(detail::command_close_path());
             } else {
                 if (p == m_cursor) {
-                    throw geometry_exception{"Zero-length segments in linestrings are not allowed."};
+                    throw geometry_exception{"Zero-length segments in rings are not allowed."};
                 }
                 m_pbf_geometry.add_element(protozero::encode_zigzag32(p.x - m_cursor.x));
                 m_pbf_geometry.add_element(protozero::encode_zigzag32(p.y - m_cursor.y));


### PR DESCRIPTION
hi! when writing features with the builder there is a protection against writing the same coordinate twice for linestrings and for rings of polygons. unfortunately, both have the same exception message mentioning linestrings specifically.

this pr changes the exception message for polygon rings to differentiate it from linestrings. 

long story short, my code protected against this problem for linestrings but i was still seeing this exception. because of the message mentioning linestrings it took me a little bit to figure out that it was actually polygons causing the issue. hopefully by updating the message to call out rings instead of linestrings anyone else hitting this will immediately know its a problem with their polygons and not their linestrings.

thanks!