### PR TITLE
CI: Remove deprecated windows-19, add windows-25

### DIFF
--- a/.github/actions/install-macos/action.yml
+++ b/.github/actions/install-macos/action.yml
@@ -6,5 +6,7 @@ runs:
     - name: Install homebrew packages
       run: |
         brew install \
-          boost
+          boost \
+          doxygen \
+          graphviz
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,8 +132,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - windows-2019
           - windows-2022
+          - windows-2025
     steps:
       - uses: actions/checkout@v4
         with:

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -11,7 +11,7 @@ message(STATUS "Configuring documentation")
 message(STATUS "Looking for doxygen")
 find_package(Doxygen)
 
-if(DOXYGEN_FOUND)
+if(DOXYGEN_FOUND AND DOXYGEN_DOT_FOUND)
     message(STATUS "Looking for doxygen - found")
     configure_file(Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
     file(GLOB HEADER_FILES "${CMAKE_SOURCE_DIR}/include/vtzero/*.hpp")


### PR DESCRIPTION
Also install Doxygen and graphviz on macOS systems to test documentation builds there.