### PR TITLE
Fix MSVC bug in feature::for_each_property

### DIFF
--- a/include/vtzero/layer.hpp
+++ b/include/vtzero/layer.hpp
@@ -468,14 +468,16 @@ namespace vtzero {
             if (!index_value{ki}.valid()) {
                 throw out_of_range_exception{ki};
             }
+            const auto k = m_layer->key(ki);
 
             assert(it != m_properties.end());
             const uint32_t vi = *it++;
             if (!index_value{vi}.valid()) {
                 throw out_of_range_exception{vi};
             }
-
-            if (!std::forward<TFunc>(func)(property{m_layer->key(ki), m_layer->value(vi)})) {
+            const auto v = m_layer->value(vi);
+            
+            if (!std::forward<TFunc>(func)(property{k, v})) {
                 return false;
             }
         }

--- a/test/fixture_tests.cpp
+++ b/test/fixture_tests.cpp
@@ -1019,3 +1019,19 @@ TEST_CASE("MVT test 058: A linestring fixture with a gigantic LineTo command") {
     REQUIRE_THROWS_WITH(vtzero::decode_geometry(geometry, geom_handler{}), "count too large");
 }
 
+TEST_CASE("MVT test 059: iterating properties of an invalid tile") {
+    std::string buffer{open_tile("041/tile.mvt")};
+    vtzero::vector_tile tile{buffer};
+
+    REQUIRE_THROWS_WITH([](vtzero::vector_tile& tile) {
+        tile.for_each_layer([&](vtzero::layer const& layer) {
+            layer.for_each_feature([&](vtzero::feature const& feature) {
+                feature.for_each_property([&](vtzero::property const& p) {
+                    return true;
+                });
+                return true;
+            });
+            return true;
+        });
+    }(tile), "index out of range: 106");
+}


### PR DESCRIPTION
When compiled with MSVC 19.43/Visual Studio 17.13, `feature::for_each_property` will fail the test case I have included. I'm still not certain if this is a compiler bug.

The issue:
When iterating properties of the test tile, indices for `key()` and `value()` are being flipped, made evident in the exception message failing with the value `77` instead of `106`, as is seen on clang and gcc. MSVC appears to be aggressively inlining the `ki` and `vi` statements into the property constructor expression. Because C++ is allowed to evaluate arguments in any order within such an expression, the values of `ki/vi` become undefined. MSVC then evaluates the arguments of the property constructor right-to-left, and the iterator is advanced in the wrong order.

The fix:
Lifting the calls to `key()` and `value()` out of the constructor expression seems to be enough for MSVC to correctly recognize the valid sequencing of the program again.
