### PR TITLE
Pass area to `ring_end` if geometry handler accepts it

### DIFF
--- a/doc/reading.md
+++ b/doc/reading.md
@@ -383,9 +383,11 @@ functions:
   times.
 * `void ring_point(vtzero::point point)`: This is called once for each
   point.
-* `void ring_end(vtzero::ring_type)`: This is called at the end of each ring.
-  The parameter tells you whether the ring is an outer or inner ring or whether
-  the ring was invalid (if the area is 0).
+* `void ring_end(vtzero::ring_type)` or `void ring_end(int64_t)`: This is called
+  at the end of each ring. The parameter tells you whether the ring is an outer
+  or inner ring or whether the ring was invalid (if the area is 0). Alternatively,
+  your handler can accept an `int64_t` parameter representing the computed ring
+  area, which can be useful for filtering small rings in downstream applications.
 
 The handler for `decode_geometry()` must implement all of the functions
 mentioned above for the different types. It is guaranteed that only one


### PR DESCRIPTION
We are calculating the ring area during decoding to determine whether the ring is an outer ring or inner ring. In some downstream applications, it's useful to know the area of the ring in addition to winding, so that it can e.g. filter small rings. This changes accepts geometry handlers with an alternative signature `ring_end(int64_t)` and calls them instead of `ring_end(ring_type)`.

Care has been taken to disallow geometry handlers that have _both_ signatures (you'll get a `call to 'classify_ring_area' is ambiguous` error message). Existing applications should continue to work as is, only accepting the ring type.